### PR TITLE
fix: Correct TOML syntax in netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,11 +4,10 @@
   
   # Output directory (Vite builds to 'dist')
   publish = "dist"
-  
-  # Node.js version
-  environment = { NODE_VERSION = "18" }
 
 [build.environment]
+  # Node.js version
+  NODE_VERSION = "18"
   # Disable Next.js telemetry (not needed for Vite)
   NEXT_TELEMETRY_DISABLED = "1"
 


### PR DESCRIPTION
- Fix environment configuration format
- Remove duplicate environment settings
- Use proper TOML section structure for build.environment
- Resolve Netlify deployment parsing errors